### PR TITLE
Update Logstash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,8 @@
-FROM docker.elastic.co/logstash/logstash:6.8.21 as base
+FROM docker.elastic.co/logstash/logstash:6.8.23
 
-RUN sed -i '/source/a source "https://repo.fury.io/fairfaxblue/"' Gemfile
-
-# This command takes 2-5 minutes due to Maven downloading and building.
-RUN /usr/share/logstash/bin/logstash-plugin install logstash-filter-prune
-RUN /usr/share/logstash/bin/logstash-plugin install logstash-filter-json_encode
 RUN /usr/share/logstash/bin/logstash-plugin install logstash-input-kinesis
-RUN /usr/share/logstash/bin/logstash-plugin install logstash-input-s3-sns-sqs
 RUN /usr/share/logstash/bin/logstash-plugin install logstash-output-kinesis
-RUN /usr/share/logstash/bin/logstash-plugin install logstash-output-google_bigquery
-# RUN /usr/share/logstash/bin/logstash-plugin install logstash-filter-de_dot
-# Above command does not work due to gem not being considered a valid logstash plugin.
-# The specification metadata is empty when installing from a remote source however when install locally works correctly.
-RUN curl -L -o /tmp/logstash-filter-de_dot.gem https://manage.fury.io/2/indexes/ruby/fairfaxblue/download/logstash-filter-de_dot-1.1.0 && \
-    /usr/share/logstash/bin/logstash-plugin install /tmp/logstash-filter-de_dot.gem && \
-    rm /tmp/logstash-filter-de_dot.gem
+RUN /usr/share/logstash/bin/logstash-plugin install logstash-filter-json_encode
 
 RUN sed -i 's|^\(-Xm.1g\)$|#\ \1|' config/jvm.options
 
@@ -29,13 +17,3 @@ RUN { \
       echo '-Xverify:none'; \
       echo '-XshowSettings:vm' ; \
     } >> config/jvm.options
-
-FROM base AS jndiremove
-
-USER root
-RUN yum install --assumeyes zip
-RUN find /usr/share/logstash -xdev -name 'log4j-core*jar' -exec zip -q -d '{}' org/apache/logging/log4j/core/lookup/JndiLookup.class \;
-
-FROM base
-
-COPY --from=jndiremove /usr/share/logstash /usr/share/logstash

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,12 +1,10 @@
-version: '2.4'
-
 services:
   logstash:
     build: .
     mem_limit: 1G
     cpu_shares: 2048
     ports:
-    - '8080'
+    - 8080
     depends_on:
     - elasticsearch
     command: [
@@ -14,24 +12,13 @@ services:
       "input { http { } } output { elasticsearch { hosts => 'http://elasticsearch' } }"
     ]
 
-  exporter:
-    image: alxrem/prometheus-logstash-exporter
-    ports:
-    - '9304'
-    command:
-    - "-logstash.host"
-    - "logstash"
-    depends_on:
-    - logstash
-
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.21
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.23
     cpu_shares: 4096
     environment:
       discovery.type: single-node
-      xpack.monitoring.collection.enabled: 'true'
-      bootstrap.memory_lock: 'true'
-      ES_JAVA_OPTS: -XshowSettings:vm
+      xpack.monitoring.collection.enabled: "true"
+      bootstrap.memory_lock: "true"
     ulimits:
       memlock:
         soft: -1
@@ -39,12 +26,12 @@ services:
     volumes:
     - elasticsearch:/usr/share/elasticsearch/data
     ports:
-    - '9200'
+    - 9200
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:6.8.21
+    image: docker.elastic.co/kibana/kibana:6.8.23
     ports:
-    - '5601'
+    - 5601
     depends_on:
     - elasticsearch
 


### PR DESCRIPTION
Update Logstash to last release of `6.x` series.

After review of our existing plugin use, we only needed the following:
- `input-kinesis`
- `input-s3-sns-sqs`
- `output-kinesis`

All other plugins have been removed.

Logstash `6.8.22` had the JNDI security fix applied so all changes related to that have been removed.

Minor cleanup / simplification of the`docker-compose.yml`. Removal of Logstash Prometheus exporter as it wasn't required for testing.

